### PR TITLE
do not pip install matplotlib

### DIFF
--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -17,4 +17,3 @@
     name={{ item }}
   with_items:
     - jupyter
-    - matplotlib


### PR DESCRIPTION
its already installed as apt package at `roles/python/tasks/main.yml`