### PR TITLE
become: yes at pip installs

### DIFF
--- a/roles/luigi/tasks/main.yml
+++ b/roles/luigi/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 - name: Install luigi via pip
+  become: yes
   pip: name=luigi version=2.1.0 # Has to be 2.1.0 to not give warnings about non-string parameters
 - name: Install sciluigi via pip
+  become: yes
   pip:
     name={{ item }}
   with_items:


### PR DESCRIPTION
we must be root to install these things globally
otherwise installation fails with cryptic
"Could not import setuptools which is required to install from a source
distribution." message